### PR TITLE
Implement local worklog saving and undo

### DIFF
--- a/WORKLOG_UNDO_IMPLEMENTATION.md
+++ b/WORKLOG_UNDO_IMPLEMENTATION.md
@@ -1,0 +1,178 @@
+# Worklog Undo Implementation
+
+This document describes the implementation of local worklog storage and undo functionality for the bookr CLI tool.
+
+## Overview
+
+The implementation adds the ability to:
+1. Locally store created worklogs for tracking and potential reversal
+2. Display worklog IDs in the `bookr today` command
+3. Undo (delete) recently created worklogs via `bookr undo` command
+
+## Features Implemented
+
+### 1. Local Worklog Storage (`src/utils/worklog-storage.ts`)
+
+- **Storage Location**: Uses `env-paths` to store data in the user's data directory
+- **File**: `~/.local/share/bookr-cli/worklogs.json` (Linux) or equivalent on other platforms
+- **Data Structure**: Stores worklog metadata including ID, issue details, time, and creation date
+- **Automatic Cleanup**: Removes worklogs older than 30 days to prevent unlimited growth
+- **Capacity Limit**: Keeps only the last 100 worklogs to prevent excessive storage usage
+
+### 2. Enhanced Today Command
+
+The `bookr today` command now displays:
+- **Worklog IDs**: Shows the JIRA worklog ID for each entry
+- **Source Indicator**: Marks external worklogs (not created via bookr) as "(external)"
+- **Improved Formatting**: Tabular display with columns for ID, Issue, Time, and Summary
+- **Comment Display**: Shows worklog comments with proper indentation
+
+**Example Output:**
+```
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ID                | Issue        | Time     | Summary
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+12345            | PROJ-123     | 2h 30m   | Fix authentication bug in user login
+                                             └─ Fixed OAuth token validation issue
+67890 (external) | PROJ-456     | 1h       | Code review for feature X
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+```
+
+### 3. Undo Command (`src/commands/undo.ts`)
+
+Two usage modes:
+
+#### Interactive Mode: `bookr undo`
+- Shows a table of recent worklogs (last 7 days) that can be undone
+- Displays worklog ID, issue, time, summary, and date
+- Only shows worklogs created via bookr CLI
+- Provides instructions for undoing specific worklogs
+
+#### Direct Mode: `bookr undo <WORKLOG_ID>`
+- Deletes a specific worklog by ID
+- Shows worklog details before deletion
+- Removes the worklog from both JIRA and local storage
+- Provides error handling for missing or inaccessible worklogs
+
+### 4. JIRA API Enhancement (`src/api/jira-client.ts`)
+
+Added `deleteWorklog` method:
+- Sends DELETE request to JIRA REST API
+- Handles authentication and error responses
+- Provides detailed error messages for debugging
+
+### 5. App Component Integration (`src/components/App.tsx`)
+
+Modified worklog creation flow:
+- Stores worklog metadata locally after successful JIRA creation
+- Preserves original comment text for storage
+- Handles storage failures gracefully without blocking worklog creation
+
+## Usage Examples
+
+### Creating a Worklog (Enhanced)
+```bash
+bookr PROJ-123 2h30m -m "Fixed authentication bug"
+# ✅ Worklog created and stored locally for potential undo
+```
+
+### Viewing Today's Worklogs with IDs
+```bash
+bookr today
+# Shows all today's worklogs with IDs and indicates which can be undone
+```
+
+### Interactive Undo
+```bash
+bookr undo
+# Shows table of recent undoable worklogs with instructions
+```
+
+### Direct Undo
+```bash
+bookr undo 12345
+# Deletes specific worklog with ID 12345
+```
+
+## Technical Implementation Details
+
+### Storage Format
+```json
+{
+  "worklogs": [
+    {
+      "id": "12345",
+      "issueKey": "PROJ-123",
+      "issueId": "10001",
+      "issueSummary": "Fix authentication bug",
+      "timeSpent": "2h30m",
+      "timeSpentSeconds": 9000,
+      "comment": "Fixed OAuth token validation",
+      "started": "2024-01-15T10:30:00.000Z",
+      "createdAt": "2024-01-15T10:30:00.000Z",
+      "author": {
+        "name": "john.doe",
+        "displayName": "John Doe"
+      }
+    }
+  ],
+  "lastCleanup": "2024-01-15T00:00:00.000Z"
+}
+```
+
+### Error Handling
+
+The implementation includes comprehensive error handling for:
+- **Storage Failures**: Graceful degradation if local storage fails
+- **JIRA API Errors**: Detailed error messages for API failures
+- **Missing Worklogs**: Clear feedback when worklog IDs aren't found
+- **Permission Issues**: Informative messages for insufficient permissions
+
+### Security Considerations
+
+- **Local Storage Only**: Worklog metadata stored locally, no external transmission
+- **Permission Respect**: Only allows deletion of user's own worklogs via JIRA API
+- **Data Validation**: Validates worklog IDs and existence before deletion attempts
+
+## CLI Command Updates
+
+Updated help text and command structure:
+
+```
+Usage
+  $ bookr [ticket] [time] [options]
+  $ bookr [time] [options]
+  $ bookr today
+  $ bookr sprint
+  $ bookr undo [worklog_id]
+
+Arguments
+  ticket     Jira ticket key (e.g., "PROJ-123") - optional, will use Git branch if not provided
+  time       Time to log (e.g., "2h 30m", "1h15m", "45m")
+  today      Show today's worklogs and total hours with IDs
+  sprint     Show worklogs for the last 14 days (sprint period)
+  undo       Delete recent worklogs (interactive) or specific worklog by ID
+
+Examples
+  $ bookr today                               # View today's worklogs with IDs
+  $ bookr undo                                # Show recent worklogs to undo
+  $ bookr undo 12345                          # Undo specific worklog by ID
+```
+
+## Benefits
+
+1. **Safety Net**: Provides ability to undo accidental or incorrect worklog entries
+2. **Transparency**: Shows clear worklog IDs for easy reference
+3. **User-Friendly**: Interactive mode for discovering undoable worklogs
+4. **Efficient**: Direct mode for quick undo operations
+5. **Non-Intrusive**: Doesn't affect existing functionality or performance
+6. **Reliable**: Robust error handling and graceful degradation
+
+## Future Enhancements
+
+Potential improvements for future versions:
+- Confirmation prompts for deletion in direct mode
+- Bulk undo operations
+- Worklog editing (time/comment modification)
+- Export/import of worklog history
+- Integration with git commit history for automatic worklog suggestions

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test:integration:issues": "vitest run test/integration/issues.test.ts",
     "test:integration:update": "vitest run test/integration/update-checker.test.ts",
     "test:integration:extraction": "vitest run test/integration/issue-extraction.test.ts",
-    "test:debug-worklogs": "tsx src/commands/today.ts --debug-worklogs OCI2025PO-372",
     "biome:lint": "biome lint .",
     "biome:check": "biome check .",
     "biome:format": "biome format . --write",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
   "bin": {
     "bookr": "dist/cli.js"
   },
-  "files": [
-    "dist/**/*",
-    "README.md"
-  ],
+  "files": ["dist/**/*", "README.md"],
   "scripts": {
     "dev": "tsx watch src/cli.ts",
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookr-cli",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "description": "A terminal-based CLI tool to book time in Jira using the Tempo plugin by parsing your current Git branch name",
   "main": "dist/cli.js",
@@ -25,6 +25,7 @@
     "test:integration:issues": "vitest run test/integration/issues.test.ts",
     "test:integration:update": "vitest run test/integration/update-checker.test.ts",
     "test:integration:extraction": "vitest run test/integration/issue-extraction.test.ts",
+    "test:debug-worklogs": "tsx src/commands/today.ts --debug-worklogs OCI2025PO-372",
     "biome:lint": "biome lint .",
     "biome:check": "biome check .",
     "biome:format": "biome format . --write",

--- a/src/api/jira-client.ts
+++ b/src/api/jira-client.ts
@@ -121,6 +121,31 @@ export class JiraClient {
   }
 
   /**
+   * Delete a worklog entry from a JIRA issue
+   */
+  async deleteWorklog(issueKey: string, worklogId: string): Promise<void> {
+    const url = `${this.auth.baseUrl}/rest/api/3/issue/${issueKey}/worklog/${worklogId}`;
+    
+    try {
+      const response = await fetch(url, {
+        method: 'DELETE',
+        headers: this.baseHeaders,
+      });
+
+      if (!response.ok) {
+        const errorData = (await response.json()) as JiraError;
+        throw new Error(
+          `Failed to delete worklog: ${errorData.errorMessages?.join(', ') || response.statusText}`
+        );
+      }
+    } catch (error) {
+      throw new Error(
+        `Error deleting worklog ${worklogId} from ${issueKey}: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  /**
    * Parse time string to seconds (helper method)
    */
   private parseTimeToSeconds(timeString: string): number {

--- a/src/api/jira-client.ts
+++ b/src/api/jira-client.ts
@@ -55,15 +55,17 @@ export class JiraClient {
       });
 
       if (!response.ok) {
-        // Try to parse as JSON first, but fall back to text if it fails
+        // Clone the response before reading it to avoid consuming the stream
+        const responseClone = response.clone();
         let errorMessage = response.statusText;
+        
         try {
           const errorData = (await response.json()) as JiraError;
           errorMessage = errorData.errorMessages?.join(', ') || response.statusText;
         } catch {
-          // If JSON parsing fails, try to get the response as text
+          // If JSON parsing fails, try to get the response as text from the cloned response
           try {
-            const textResponse = await response.text();
+            const textResponse = await responseClone.text();
             errorMessage = textResponse || response.statusText;
           } catch {
             errorMessage = response.statusText;

--- a/src/api/jira-client.ts
+++ b/src/api/jira-client.ts
@@ -125,7 +125,7 @@ export class JiraClient {
    */
   async deleteWorklog(issueKey: string, worklogId: string): Promise<void> {
     const url = `${this.auth.baseUrl}/rest/api/3/issue/${issueKey}/worklog/${worklogId}`;
-    
+
     try {
       const response = await fetch(url, {
         method: 'DELETE',

--- a/src/api/jira-client.ts
+++ b/src/api/jira-client.ts
@@ -260,7 +260,7 @@ export class JiraClient {
   }
 
   /**
-   * Get today's worklogs for the current user
+   * Get today's worklogs for all authors
    */
   async getTodayWorklogs(): Promise<Array<{ issue: JiraIssue; worklog: JiraWorklog }>> {
     const today = new Date();
@@ -271,8 +271,8 @@ export class JiraClient {
     const startDate = startOfDay.toISOString().split('T')[0];
     const endDate = endOfDay.toISOString().split('T')[0];
 
-    // Search for issues with worklogs created today by current user
-    const jql = `worklogDate >= "${startDate}" AND worklogDate <= "${endDate}" AND worklogAuthor = currentUser() ORDER BY updated DESC`;
+    // Search for issues with worklogs created today (any author)
+    const jql = `worklogDate >= "${startDate}" AND worklogDate <= "${endDate}" ORDER BY updated DESC`;
 
     try {
       const result = await this.searchIssues(jql, 50);

--- a/src/api/tempo-client.ts
+++ b/src/api/tempo-client.ts
@@ -1,0 +1,68 @@
+/**
+ * Tempo API client for worklog-related tasks
+ * Docs: https://apidocs.tempo.io/
+ */
+
+import { loadConfigFromFile } from '../utils/config.js';
+
+export class TempoClient {
+  private baseUrl: string;
+  private apiToken: string;
+
+  constructor(baseUrl: string, apiToken: string) {
+    this.baseUrl = baseUrl;
+    this.apiToken = apiToken;
+  }
+
+  /**
+   * Fetch worklogs for a user for a given date range (Tempo API v4)
+   */
+  async getWorklogsForUser(accountId: string, from: string, to: string) {
+    const url = `${this.baseUrl}/worklogs/user/${encodeURIComponent(accountId)}`;
+    const params = new URLSearchParams({ from, to, limit: '1000' });
+    const response = await fetch(`${url}?${params.toString()}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${this.apiToken}`,
+        'Accept': 'application/json',
+      },
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to fetch Tempo worklogs: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+    return await response.json();
+  }
+
+  /**
+   * Add a worklog for a user
+   */
+  async addWorklog(_worklogData: any) {
+    // TODO: Implement API call to add a worklog
+    // Endpoint: POST /worklogs
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Delete a worklog by ID
+   */
+  async deleteWorklog(_worklogId: string) {
+    // TODO: Implement API call to delete a worklog
+    // Endpoint: DELETE /worklogs/{id}
+    throw new Error('Not implemented');
+  }
+}
+
+export function createTempoClient(): TempoClient {
+  const fileConfig = loadConfigFromFile();
+  const baseUrl =  'https://api.tempo.io/4';
+  const apiToken = fileConfig?.tempoApiToken;
+
+  if (!baseUrl || !apiToken) {
+    throw new Error(
+      'Missing Tempo configuration. Please set tempoApiToken in your config file.'
+    );
+  }
+
+  return new TempoClient(baseUrl, apiToken);
+} 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,12 +19,14 @@ async function main() {
       $ bookr [time] [options]
       $ bookr today
       $ bookr sprint
+      $ bookr undo [worklog_id]
 
     Arguments
-      ticket  Jira ticket key (e.g., "PROJ-123") - optional, will use Git branch if not provided
-      time    Time to log (e.g., "2h 30m", "1h15m", "45m")
-      today   Show today's worklogs and total hours
-      sprint  Show worklogs for the last 14 days (sprint period)
+      ticket     Jira ticket key (e.g., "PROJ-123") - optional, will use Git branch if not provided
+      time       Time to log (e.g., "2h 30m", "1h15m", "45m")
+      today      Show today's worklogs and total hours with IDs
+      sprint     Show worklogs for the last 14 days (sprint period)
+      undo       Delete recent worklogs (interactive) or specific worklog by ID
 
     Options
       --help, -h        Show help
@@ -40,6 +42,8 @@ async function main() {
       $ bookr --date "2024-01-15" 4h         # With specific date
       $ bookr today
       $ bookr sprint
+      $ bookr undo                            # Show recent worklogs to undo
+      $ bookr undo 12345                      # Undo specific worklog by ID
       $ bookr update                          # Check for updates
     `,
     {
@@ -81,6 +85,14 @@ async function main() {
   if (input[0] === 'init') {
     const command = await import('./commands/init.js');
     await command.default();
+    return;
+  }
+
+  // Handle "undo" command
+  if (input[0] === 'undo') {
+    const command = await import('./commands/undo.js');
+    const worklogId = input[1]; // Optional worklog ID
+    await command.default(worklogId);
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ async function main() {
       $ bookr today
       $ bookr sprint
       $ bookr undo [worklog_id]
+      $ bookr init
 
     Arguments
       ticket     Jira ticket key (e.g., "PROJ-123") - optional, will use Git branch if not provided
@@ -27,6 +28,8 @@ async function main() {
       today      Show today's worklogs and total hours with IDs
       sprint     Show worklogs for the last 14 days (sprint period)
       undo       Delete recent worklogs (interactive) or specific worklog by ID
+      init       Set up JIRA and Tempo credentials
+      tempo      Add Tempo API token to existing configuration
 
     Options
       --help, -h        Show help
@@ -87,6 +90,8 @@ async function main() {
     await command.default();
     return;
   }
+
+
 
   // Handle "undo" command
   if (input[0] === 'undo') {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import envPaths from 'env-paths';
 import inquirer from 'inquirer';
+import { loadConfigFromFile } from '../utils/config.js';
 
 const paths = envPaths('bookr');
 const configDir = paths.config;
@@ -39,12 +40,67 @@ async function promptForConfig() {
   return await inquirer.prompt(questions);
 }
 
+async function promptForTempoToken() {
+  const questions = [
+    {
+      type: 'password' as const,
+      name: 'TEMPO_API_TOKEN',
+      message: 'Tempo API Token (from https://id.tempo.io/manage/api-tokens):',
+      mask: '*',
+      validate: (input: string) => input.length > 0 || 'Tempo API token cannot be empty.',
+    },
+  ];
+  return await inquirer.prompt(questions);
+}
+
 async function saveConfig(config: Record<string, string>) {
   await fs.promises.mkdir(configDir, { recursive: true });
   await fs.promises.writeFile(configFile, JSON.stringify(config, null, 2), { mode: 0o600 });
 }
 
+
+
 export async function init() {
+  const existingConfig = loadConfigFromFile();
+  
+  if (existingConfig?.baseUrl && existingConfig?.email && existingConfig?.apiToken) {
+    console.log('🔧 Bookr Init: Configuration already exists\n');
+    
+    if (!existingConfig.tempoApiToken) {
+      console.log('📝 Tempo API token is missing. Would you like to add it?');
+      const { addTempo } = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'addTempo',
+          message: 'Add Tempo API token to existing configuration?',
+          default: true,
+        },
+      ]);
+      
+      if (addTempo) {
+        console.log('🔧 Bookr: Add Tempo API Token to existing configuration\n');
+        console.log('🔧 https://indicia-nl.atlassian.net/plugins/servlet/ac/io.tempo.jira/tempo-app#!/configuration/api-integration\n');
+        
+        const tempoConfig = await promptForTempoToken();
+        
+        // Merge existing config with new Tempo token
+        const updatedConfig: Record<string, string> = {
+          JIRA_BASE_URL: existingConfig.baseUrl,
+          JIRA_EMAIL: existingConfig.email,
+          JIRA_API_TOKEN: existingConfig.apiToken,
+          TEMPO_API_TOKEN: tempoConfig['TEMPO_API_TOKEN'],
+        };
+        
+        await saveConfig(updatedConfig);
+        console.log(`\n✅ Tempo API token added to configuration at ${configFile}`);
+        return;
+      }
+    }
+    
+    console.log('✅ Configuration is already complete. No changes needed.');
+    return;
+  }
+  
   console.log('🔧 Bookr Init: Set up your JIRA credentials\n');
   const config = await promptForConfig();
   await saveConfig(config);
@@ -53,6 +109,8 @@ export async function init() {
 
 // Default export for CLI usage
 export default init;
+
+
 
 // For backward compatibility when running directly
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -28,6 +28,13 @@ async function promptForConfig() {
       mask: '*',
       validate: (input: string) => input.length > 0 || 'API token cannot be empty.',
     },
+    {
+      type: 'password' as const,
+      name: 'TEMPO_API_TOKEN',
+      message: 'Tempo API Token (from https://id.tempo.io/manage/api-tokens) [optional]:',
+      mask: '*',
+      validate: (_input: string) => true, // Optional
+    },
   ];
   return await inquirer.prompt(questions);
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -90,7 +90,11 @@ export async function init() {
         
         if (addTempo) {
           console.log('🔧 Bookr: Add Tempo API Token to existing configuration\n');
-          console.log('🔧 https://indicia-nl.atlassian.net/plugins/servlet/ac/io.tempo.jira/tempo-app#!/configuration/api-integration\n');
+          
+          // Extract hostname from JIRA base URL to construct Tempo URL
+          const jiraUrl = new URL(existingConfig.baseUrl);
+          const tempoUrl = `https://${jiraUrl.hostname}/plugins/servlet/ac/io.tempo.jira/tempo-app#!/configuration/api-integration`;
+          console.log(`🔧 ${tempoUrl}\n`);
           
           const tempoConfig = await promptForTempoToken();
           

--- a/src/commands/sprint.ts
+++ b/src/commands/sprint.ts
@@ -1,8 +1,7 @@
 import inquirer from 'inquirer';
 import { type JiraClient, createClient } from '../api/jira-client.js';
-import type { JiraIssue, JiraWorklog } from '../types/jira.js';
+import { createTempoClient } from '../api/tempo-client.js';
 import { formatDateRange } from '../utils/date.js';
-import { extractCommentText } from '../utils/jira.js';
 import { secondsToJiraFormat } from '../utils/time-parser.js';
 
 function parseArgs(): { history: boolean } {
@@ -23,8 +22,6 @@ async function selectSprint(client: JiraClient): Promise<{
     console.log('❌ No boards found.');
     return null;
   }
-
-  // If there's only one board, use it directly
   let boardId: number;
   if (boards.length === 1) {
     const board = boards[0];
@@ -35,13 +32,11 @@ async function selectSprint(client: JiraClient): Promise<{
     boardId = board.id;
     console.log(`📋 Using board: ${board.name}`);
   } else {
-    // Let user select a board
     const boardChoices = boards.map((board: { id: number; name: string }) => ({
       name: board.name,
       value: board.id,
       short: board.name,
     }));
-
     const { selectedBoardId } = await inquirer.prompt([
       {
         type: 'list',
@@ -53,15 +48,12 @@ async function selectSprint(client: JiraClient): Promise<{
     ]);
     boardId = selectedBoardId;
   }
-
   const sprints = await client.getSprintsForBoard(boardId);
   if (!sprints.length) {
     console.log('❌ No sprints found for the selected board.');
     return null;
   }
-
   console.log(`📊 Found ${sprints.length} sprints for this board.`);
-
   const choices = sprints.map(
     (sprint: {
       id: number;
@@ -87,17 +79,25 @@ async function selectSprint(client: JiraClient): Promise<{
   return sprints.find((s: { id: number }) => s.id === sprintId) || null;
 }
 
+// Helper to limit concurrency for parallel fetches
+async function parallelMapLimit<T, R>(arr: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const ret: R[] = [];
+  let i = 0;
+  async function next() {
+    if (i >= arr.length) return;
+    const idx = i++;
+    const item = arr[idx];
+    ret[idx] = item !== undefined ? await fn(item) : undefined as any;
+    await next();
+  }
+  await Promise.all(Array(Math.min(limit, arr.length)).fill(0).map(next));
+  return ret;
+}
+
 export async function showSprintWorklogs() {
   try {
     const client = createClient();
-
-    // Test connection
-    const isConnected = await client.testConnection();
-    if (!isConnected) {
-      console.log('❌ Failed to connect to JIRA');
-      return;
-    }
-
+    const tempoClient = createTempoClient();
     const { history } = parseArgs();
     let sprint: {
       id: number;
@@ -121,104 +121,55 @@ export async function showSprintWorklogs() {
     }
     const startDate = new Date(sprint.startDate);
     const endDate = new Date(sprint.endDate);
-    const dateRange = formatDateRange(startDate, endDate);
-
-    console.log(`🔄 Fetching worklogs for sprint: ${sprint.name}`);
-    console.log(
-      `📅 Searching for worklogs between: ${startDate.toISOString()} and ${endDate.toISOString()}`
-    );
-    console.log(
-      `📅 Date range: ${startDate.toLocaleDateString()} to ${endDate.toLocaleDateString()}`
-    );
-
-    try {
-      // Use the new method that searches for worklogs within the exact date range
-      console.log('🔍 Starting worklog search...');
-      const worklogsWithIssues = await client.searchWorklogsByDateRange(startDate, endDate);
-      console.log(`📊 Found ${worklogsWithIssues.length} worklog entries for this sprint period.`);
-
-      // Display sprint header
-      console.log('─'.repeat(80));
-      console.log(`🏃‍♂️  SPRINT WORKLOGS: ${sprint.name} (${dateRange})`);
-      console.log('─'.repeat(80));
-
-      if (worklogsWithIssues.length === 0) {
-        console.log('📭 No worklogs found for this sprint period.');
-        console.log(`📊 Sprint period: ${dateRange}`);
-        console.log(`📊 Current date: ${new Date().toLocaleDateString()}`);
-        return;
-      }
-
-      // Calculate total time
-      let totalSeconds = 0;
-
-      // Group worklogs by date
-      const worklogsByDate: Record<string, Array<{ issue: JiraIssue; worklog: JiraWorklog }>> = {};
-
-      for (const { issue, worklog } of worklogsWithIssues) {
-        const timeSpent = worklog.timeSpentSeconds || 0;
-        totalSeconds += timeSpent;
-
-        if (!worklog.started) continue; // Skip worklogs without start date
-
-        const worklogDate = new Date(worklog.started);
-        const dateKey = worklogDate.toLocaleDateString();
-
-        if (!worklogsByDate[dateKey]) {
-          worklogsByDate[dateKey] = [];
-        }
-        worklogsByDate[dateKey].push({ issue, worklog });
-      }
-
-      // Display worklogs grouped by date
-      for (const [date, dayWorklogs] of Object.entries(worklogsByDate)) {
-        console.log(`\n📅 ${date}:`);
-        console.log('─'.repeat(40));
-
-        let dayTotal = 0;
-
-        for (const { issue, worklog } of dayWorklogs) {
-          const timeSpent = worklog.timeSpentSeconds || 0;
-          dayTotal += timeSpent;
-          const timeDisplay = secondsToJiraFormat(timeSpent);
-          const comment = extractCommentText(worklog.comment);
-
-          console.log(`${issue.key.padEnd(12)} | ${issue.fields.summary}`);
-          if (comment && comment !== 'No comment') {
-            console.log(`${timeDisplay.padEnd(12)} - ${comment}`);
-          }
-          console.log('');
-        }
-
-        const dayTotalDisplay = secondsToJiraFormat(dayTotal);
-        console.log(`📊 Day Total: ${dayTotalDisplay}`);
-      }
-
-      // Display summary
-      console.log('─'.repeat(80));
-      const totalTime = secondsToJiraFormat(totalSeconds);
-      const totalHours = (totalSeconds / 3600).toFixed(2);
-
-      console.log('📊 Sprint Summary:');
-      console.log(`   Period: ${dateRange}`);
-      console.log(`   Total Time: ${totalTime} (${totalHours} hours)`);
-      console.log(`   Worklog Entries: ${worklogsWithIssues.length}`);
-
-      // Calculate average time per day
-      const sprintDays =
-        Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
-      const avgTimePerDay = totalSeconds / sprintDays;
-      const avgTimePerDayDisplay = secondsToJiraFormat(avgTimePerDay);
-      console.log(`   Average Time per Day: ${avgTimePerDayDisplay}`);
-
-      // Show unique issues worked on
-      const uniqueIssues = new Set(worklogsWithIssues.map((w) => w.issue.key)).size;
-      console.log(`   Issues Worked On: ${uniqueIssues}`);
-    } catch (error) {
-      throw new Error(
-        `Error fetching sprint worklogs: ${error instanceof Error ? error.message : 'Unknown error'}`
-      );
+    const fromISO = startDate.toISOString().slice(0, 10);
+    const toISO = endDate.toISOString().slice(0, 10);
+    const user = await client.getCurrentUser();
+    console.log(`${sprint.name}`);
+    console.log(`${fromISO} to ${toISO}`);
+    const tempoWorklogsResponse = await tempoClient.getWorklogsForUser(user.accountId, fromISO, toISO);
+    const tempoWorklogs = (tempoWorklogsResponse && typeof tempoWorklogsResponse === 'object' && Array.isArray((tempoWorklogsResponse as any).results))
+      ? (tempoWorklogsResponse as any).results
+      : Array.isArray(tempoWorklogsResponse) ? tempoWorklogsResponse : [];
+    if (!tempoWorklogs.length) {
+      console.log('📭 No worklogs found for this sprint period.');
+      return;
     }
+    // Collect unique issue IDs
+    const uniqueIssueIds = Array.from(new Set((tempoWorklogs as any[]).map((w: any) => w.issue?.id).filter(Boolean)));
+    // Fetch all issues in parallel (limit concurrency to 5)
+    const issueMap = new Map();
+    await parallelMapLimit(uniqueIssueIds, 5, async (id) => {
+      try {
+        const issue = await client.getIssue(String(id));
+        issueMap.set(id, { key: issue.key, summary: issue.fields.summary });
+      } catch {
+        // If not found, skip
+      }
+    });
+    // Table header
+    console.log('─'.repeat(120));
+    console.log(`${'ID'.padEnd(17)} | ${'Issue'.padEnd(12)} | ${'Time'.padEnd(8)} | Summary`);
+    console.log('─'.repeat(120));
+    let totalSeconds = 0;
+    const uniqueIssues = new Set<string>();
+    for (const worklog of tempoWorklogs as any[]) {
+      const timeSpentSeconds = worklog.timeSpentSeconds || worklog.timeSpent || 0;
+      totalSeconds += timeSpentSeconds;
+      const timeDisplay = secondsToJiraFormat(timeSpentSeconds);
+      const issueId = worklog.issue?.id || '';
+      const issueInfo = issueMap.get(issueId) || {};
+      const issueKey = issueInfo.key || '';
+      uniqueIssues.add(String(issueKey));
+      const summary = issueInfo.summary || worklog.description || '';
+      const worklogId = worklog.tempoWorklogId ? String(worklog.tempoWorklogId) : String(worklog.id || '');
+      console.log(`${worklogId.padEnd(17)} | ${issueKey.padEnd(12)} | ${timeDisplay.padEnd(8)} | ${summary}`);
+    }
+    console.log('─'.repeat(120));
+    const totalTime = secondsToJiraFormat(totalSeconds);
+    const totalHours = (totalSeconds / 3600).toFixed(2);
+    console.log(`📊 Sprint Total: ${totalTime} (${totalHours} hours)`);
+    console.log(`📝 Worklog entries: ${tempoWorklogs.length}`);
+    console.log(`🎯 Issues worked on: ${uniqueIssues.size}`);
   } catch (error) {
     console.error('❌ Error:', error instanceof Error ? error.message : error);
   }

--- a/src/commands/sprint.ts
+++ b/src/commands/sprint.ts
@@ -148,7 +148,7 @@ export async function showSprintWorklogs() {
     });
     // Table header
     console.log('─'.repeat(120));
-    console.log(`${'ID'.padEnd(17)} | ${'Issue'.padEnd(12)} | ${'Time'.padEnd(8)} | Summary`);
+    console.log(`${'ID'.padEnd(12)} | ${'Issue'.padEnd(16)} | ${'Time'.padEnd(6)} | Summary`);
     console.log('─'.repeat(120));
     let totalSeconds = 0;
     const uniqueIssues = new Set<string>();
@@ -162,7 +162,7 @@ export async function showSprintWorklogs() {
       uniqueIssues.add(String(issueKey));
       const summary = issueInfo.summary || worklog.description || '';
       const worklogId = worklog.tempoWorklogId ? String(worklog.tempoWorklogId) : String(worklog.id || '');
-      console.log(`${worklogId.padEnd(17)} | ${issueKey.padEnd(12)} | ${timeDisplay.padEnd(8)} | ${summary}`);
+      console.log(`${worklogId.padEnd(12)} | ${issueKey.padEnd(16)} | ${timeDisplay.padEnd(6)} | ${summary}`);
     }
     console.log('─'.repeat(120));
     const totalTime = secondsToJiraFormat(totalSeconds);

--- a/src/commands/sprint.ts
+++ b/src/commands/sprint.ts
@@ -3,6 +3,8 @@ import { type JiraClient, createClient } from '../api/jira-client.js';
 import { createTempoClient } from '../api/tempo-client.js';
 import { formatDateRange } from '../utils/date.js';
 import { secondsToJiraFormat } from '../utils/time-parser.js';
+import { parallelMapLimit } from '../utils/concurrency.js';
+import type { TempoWorklog, TempoWorklogsResponse } from '../types/tempo.js';
 
 function parseArgs(): { history: boolean } {
   return {
@@ -79,20 +81,7 @@ async function selectSprint(client: JiraClient): Promise<{
   return sprints.find((s: { id: number }) => s.id === sprintId) || null;
 }
 
-// Helper to limit concurrency for parallel fetches
-async function parallelMapLimit<T, R>(arr: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
-  const ret: R[] = [];
-  let i = 0;
-  async function next() {
-    if (i >= arr.length) return;
-    const idx = i++;
-    const item = arr[idx];
-    ret[idx] = item !== undefined ? await fn(item) : undefined as any;
-    await next();
-  }
-  await Promise.all(Array(Math.min(limit, arr.length)).fill(0).map(next));
-  return ret;
-}
+
 
 export async function showSprintWorklogs() {
   try {
@@ -127,15 +116,15 @@ export async function showSprintWorklogs() {
     console.log(`${sprint.name}`);
     console.log(`${fromISO} to ${toISO}`);
     const tempoWorklogsResponse = await tempoClient.getWorklogsForUser(user.accountId, fromISO, toISO);
-    const tempoWorklogs = (tempoWorklogsResponse && typeof tempoWorklogsResponse === 'object' && Array.isArray((tempoWorklogsResponse as any).results))
-      ? (tempoWorklogsResponse as any).results
-      : Array.isArray(tempoWorklogsResponse) ? tempoWorklogsResponse : [];
+    const tempoWorklogs = (tempoWorklogsResponse && typeof tempoWorklogsResponse === 'object' && Array.isArray((tempoWorklogsResponse as TempoWorklogsResponse).results))
+      ? (tempoWorklogsResponse as TempoWorklogsResponse).results
+      : Array.isArray(tempoWorklogsResponse) ? tempoWorklogsResponse as TempoWorklog[] : [];
     if (!tempoWorklogs.length) {
       console.log('📭 No worklogs found for this sprint period.');
       return;
     }
     // Collect unique issue IDs
-    const uniqueIssueIds = Array.from(new Set((tempoWorklogs as any[]).map((w: any) => w.issue?.id).filter(Boolean)));
+    const uniqueIssueIds = Array.from(new Set(tempoWorklogs.map((w: TempoWorklog) => w.issue?.id).filter(Boolean)));
     // Fetch all issues in parallel (limit concurrency to 5)
     const issueMap = new Map();
     await parallelMapLimit(uniqueIssueIds, 5, async (id) => {
@@ -152,8 +141,8 @@ export async function showSprintWorklogs() {
     console.log('─'.repeat(120));
     let totalSeconds = 0;
     const uniqueIssues = new Set<string>();
-    for (const worklog of tempoWorklogs as any[]) {
-      const timeSpentSeconds = worklog.timeSpentSeconds || worklog.timeSpent || 0;
+    for (const worklog of tempoWorklogs) {
+      const timeSpentSeconds = typeof worklog.timeSpentSeconds === 'number' ? worklog.timeSpentSeconds : 0;
       totalSeconds += timeSpentSeconds;
       const timeDisplay = secondsToJiraFormat(timeSpentSeconds);
       const issueId = worklog.issue?.id || '';

--- a/src/commands/today.ts
+++ b/src/commands/today.ts
@@ -47,9 +47,9 @@ export async function showTodayWorklogs() {
     });
 
     // Table header
-    console.log('─'.repeat(120));
-    console.log(`${'ID'.padEnd(17)} | ${'Issue'.padEnd(12)} | ${'Time'.padEnd(8)} | Summary`);
-    console.log('─'.repeat(120));
+    console.log('─'.repeat(140));
+    console.log(`${'Tempo ID'.padEnd(12)} | ${'Jira ID'.padEnd(12)} | ${'Issue'.padEnd(16)} | ${'Time'.padEnd(6)} | Summary`);
+    console.log('─'.repeat(140));
     let totalSeconds = 0;
     const uniqueIssues = new Set<string>();
     for (const worklog of tempoWorklogs as any[]) {
@@ -61,10 +61,11 @@ export async function showTodayWorklogs() {
       const issueKey = issueInfo.key || '';
       uniqueIssues.add(String(issueKey));
       const summary = issueInfo.summary || worklog.description || '';
-      const worklogId = worklog.tempoWorklogId ? String(worklog.tempoWorklogId) : String(worklog.id || '');
-      console.log(`${worklogId.padEnd(17)} | ${issueKey.padEnd(12)} | ${timeDisplay.padEnd(8)} | ${summary}`);
+      const tempoId = worklog.tempoWorklogId ? String(worklog.tempoWorklogId) : '';
+      const jiraId = worklog.id ? String(worklog.id) : '';
+      console.log(`${tempoId.padEnd(12)} | ${jiraId.padEnd(12)} | ${issueKey.padEnd(16)} | ${timeDisplay.padEnd(6)} | ${summary}`);
     }
-    console.log('─'.repeat(120));
+    console.log('─'.repeat(140));
     const totalTime = secondsToJiraFormat(totalSeconds);
     const totalHours = (totalSeconds / 3600).toFixed(2);
     console.log(`📊 Total time today: ${totalTime} (${totalHours} hours)`);

--- a/src/commands/today.ts
+++ b/src/commands/today.ts
@@ -34,18 +34,18 @@ export async function showTodayWorklogs() {
       const timeDisplay = secondsToJiraFormat(timeSpent);
       const comment = extractCommentText(worklog.comment);
       
-      // Show worklog ID if it's a stored worklog (created via bookr)
+      // Show worklog ID - all worklogs can be undone, but indicate source
       const worklogId = worklog.id || 'N/A';
       const isStoredWorklog = storedWorklogMap.has(worklogId);
-      const idDisplay = isStoredWorklog ? worklogId : `${worklogId} (external)`;
+      const source = isStoredWorklog ? ' (bookr)' : '';
       
-      console.log(`${idDisplay.padEnd(17)} | ${issue.key.padEnd(12)} | ${timeDisplay.padEnd(8)} | ${issue.fields.summary}`);
+      console.log(`${(worklogId + source).padEnd(17)} | ${issue.key.padEnd(12)} | ${timeDisplay.padEnd(8)} | ${issue.fields.summary}`);
       
       if (comment && comment !== 'No comment') {
         console.log(`${' '.repeat(42)} └─ ${comment}`);
       }
     }
-    console.log('─'.repeat(80));
+    console.log('─'.repeat(120));
     const totalTime = secondsToJiraFormat(totalSeconds);
     const totalHours = (totalSeconds / 3600).toFixed(2);
     console.log(`📊 Total time today: ${totalTime} (${totalHours} hours)`);

--- a/src/commands/today.ts
+++ b/src/commands/today.ts
@@ -20,27 +20,29 @@ export async function showTodayWorklogs() {
     }
     // Get stored worklogs for showing IDs
     const storedWorklogs = getTodaysStoredWorklogs();
-    const storedWorklogMap = new Map(storedWorklogs.map(w => [w.id, w]));
+    const storedWorklogMap = new Map(storedWorklogs.map((w) => [w.id, w]));
 
     // Calculate total time and display worklogs
     let totalSeconds = 0;
     console.log('─'.repeat(120));
     console.log(`${'ID'.padEnd(17)} | ${'Issue'.padEnd(12)} | ${'Time'.padEnd(8)} | Summary`);
     console.log('─'.repeat(120));
-    
+
     for (const { issue, worklog } of todayWorklogs) {
       const timeSpent = worklog.timeSpentSeconds || 0;
       totalSeconds += timeSpent;
       const timeDisplay = secondsToJiraFormat(timeSpent);
       const comment = extractCommentText(worklog.comment);
-      
+
       // Show worklog ID - all worklogs can be undone, but indicate source
       const worklogId = worklog.id || 'N/A';
       const isStoredWorklog = storedWorklogMap.has(worklogId);
       const source = isStoredWorklog ? ' (bookr)' : '';
-      
-      console.log(`${(worklogId + source).padEnd(17)} | ${issue.key.padEnd(12)} | ${timeDisplay.padEnd(8)} | ${issue.fields.summary}`);
-      
+
+      console.log(
+        `${(worklogId + source).padEnd(17)} | ${issue.key.padEnd(12)} | ${timeDisplay.padEnd(8)} | ${issue.fields.summary}`
+      );
+
       if (comment && comment !== 'No comment') {
         console.log(`${' '.repeat(42)} └─ ${comment}`);
       }

--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -1,10 +1,22 @@
-import { createClient } from '../api/jira-client.js';
-import { 
-  getRecentStoredWorklogs, 
-  getStoredWorklogById, 
-  removeStoredWorklog
-} from '../utils/worklog-storage.js';
+import { type JiraClient, createClient } from '../api/jira-client.js';
 import { secondsToJiraFormat } from '../utils/time-parser.js';
+import {
+  getRecentStoredWorklogs,
+  getStoredWorklogById,
+  removeStoredWorklog,
+} from '../utils/worklog-storage.js';
+
+interface JiraRichTextContent {
+  content?: Array<{
+    content?: Array<{
+      text?: string;
+      type?: string;
+    }>;
+    type?: string;
+  }>;
+  type?: string;
+  version?: number;
+}
 
 /**
  * Show interactive selection of recent worklogs to undo
@@ -12,7 +24,7 @@ import { secondsToJiraFormat } from '../utils/time-parser.js';
 export async function showUndoSelection() {
   try {
     const client = createClient();
-    
+
     // Test connection
     const isConnected = await client.testConnection();
     if (!isConnected) {
@@ -22,7 +34,7 @@ export async function showUndoSelection() {
 
     // Get all recent worklogs from JIRA (not just locally stored ones)
     const todayWorklogs = await client.getTodayWorklogs();
-    
+
     if (todayWorklogs.length === 0) {
       console.log('📭 No worklogs found for today.');
       console.log('💡 You can undo any worklog by its ID: bookr undo <WORKLOG_ID>');
@@ -31,23 +43,26 @@ export async function showUndoSelection() {
 
     // Get stored worklogs for showing which ones were created via bookr
     const storedWorklogs = getRecentStoredWorklogs(7);
-    const storedWorklogMap = new Map(storedWorklogs.map(w => [w.id, w]));
+    const storedWorklogMap = new Map(storedWorklogs.map((w) => [w.id, w]));
 
-    console.log('🔄 Today\'s worklogs that can be undone:');
+    console.log("🔄 Today's worklogs that can be undone:");
     console.log('─'.repeat(120));
-    console.log(`${'ID'.padEnd(17)} | ${'Issue'.padEnd(12)} | ${'Time'.padEnd(8)} | ${'Summary'.padEnd(50)} | Source`);
+    console.log(
+      `${'ID'.padEnd(17)} | ${'Issue'.padEnd(12)} | ${'Time'.padEnd(8)} | ${'Summary'.padEnd(50)} | Source`
+    );
     console.log('─'.repeat(120));
 
     for (const { issue, worklog } of todayWorklogs) {
       const worklogId = worklog.id || 'N/A';
       const timeDisplay = secondsToJiraFormat(worklog.timeSpentSeconds || 0);
-      const summary = issue.fields.summary.length > 48 
-        ? issue.fields.summary.substring(0, 45) + '...' 
-        : issue.fields.summary;
-      
+      const summary =
+        issue.fields.summary.length > 48
+          ? `${issue.fields.summary.substring(0, 45)}...`
+          : issue.fields.summary;
+
       const isFromBookr = storedWorklogMap.has(worklogId);
       const source = isFromBookr ? 'bookr' : 'other';
-      
+
       console.log(
         `${worklogId.padEnd(17)} | ${issue.key.padEnd(12)} | ${timeDisplay.padEnd(8)} | ${summary.padEnd(50)} | ${source}`
       );
@@ -58,7 +73,6 @@ export async function showUndoSelection() {
     console.log('💡 To undo a specific worklog, run: bookr undo <WORKLOG_ID>');
     console.log('💡 You can undo ANY worklog that you have permission to delete');
     console.log('⚠️  Warning: This will permanently delete the worklog from JIRA!');
-
   } catch (error) {
     console.error('❌ Error:', error instanceof Error ? error.message : error);
   }
@@ -67,7 +81,7 @@ export async function showUndoSelection() {
 /**
  * Find worklog details by searching recent worklogs
  */
-async function findWorklogDetails(client: any, worklogId: string) {
+async function findWorklogDetails(client: JiraClient, worklogId: string) {
   try {
     // First check local storage for quick lookup
     const storedWorklog = getStoredWorklogById(worklogId);
@@ -79,12 +93,12 @@ async function findWorklogDetails(client: any, worklogId: string) {
           timeSpentSeconds: storedWorklog.timeSpentSeconds,
           timeSpent: storedWorklog.timeSpent,
           comment: storedWorklog.comment,
-          started: storedWorklog.started
+          started: storedWorklog.started,
         },
         issue: {
           key: storedWorklog.issueKey,
-          fields: { summary: storedWorklog.issueSummary }
-        }
+          fields: { summary: storedWorklog.issueSummary },
+        },
       };
     }
 
@@ -100,7 +114,7 @@ async function findWorklogDetails(client: any, worklogId: string) {
     const endDate = new Date();
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - 7);
-    
+
     const recentWorklogs = await client.searchWorklogsByDateRange(startDate, endDate);
     for (const { issue, worklog } of recentWorklogs) {
       if (worklog.id === worklogId) {
@@ -109,7 +123,7 @@ async function findWorklogDetails(client: any, worklogId: string) {
     }
 
     return null;
-  } catch (error) {
+  } catch {
     return null;
   }
 }
@@ -120,7 +134,7 @@ async function findWorklogDetails(client: any, worklogId: string) {
 export async function undoWorklogById(worklogId: string) {
   try {
     const client = createClient();
-    
+
     // Test connection
     const isConnected = await client.testConnection();
     if (!isConnected) {
@@ -132,40 +146,39 @@ export async function undoWorklogById(worklogId: string) {
 
     // Try to find worklog details
     const worklogDetails = await findWorklogDetails(client, worklogId);
-    
+
     if (worklogDetails) {
       // Show worklog details for confirmation
       console.log('🔄 About to delete the following worklog:');
       console.log('─'.repeat(80));
       console.log(`Issue: ${worklogDetails.issue.key} - ${worklogDetails.issue.fields.summary}`);
       console.log(`Time: ${secondsToJiraFormat(worklogDetails.worklog.timeSpentSeconds || 0)}`);
-      
+
       // Extract comment text properly
       let comment = '';
       if (typeof worklogDetails.worklog.comment === 'string') {
         comment = worklogDetails.worklog.comment;
-      } else if (worklogDetails.worklog.comment && typeof worklogDetails.worklog.comment === 'object') {
+      } else if (
+        worklogDetails.worklog.comment &&
+        typeof worklogDetails.worklog.comment === 'object'
+      ) {
         // Handle JIRA's rich text format
         try {
-          const content = worklogDetails.worklog.comment as any;
+          const content = worklogDetails.worklog.comment as JiraRichTextContent;
           if (content.content && Array.isArray(content.content)) {
             comment = content.content
-              .map((paragraph: any) => 
-                paragraph.content
-                  ?.map((text: any) => text.text || '')
-                  .join('')
-              )
+              .map((paragraph) => paragraph.content?.map((text) => text.text || '').join(''))
               .join('\n');
           }
         } catch {
           comment = 'Rich text comment';
         }
       }
-      
+
       if (comment) {
         console.log(`Comment: ${comment}`);
       }
-      
+
       const date = new Date(worklogDetails.worklog.started || '').toLocaleString();
       console.log(`Date: ${date}`);
       console.log('─'.repeat(80));
@@ -175,15 +188,19 @@ export async function undoWorklogById(worklogId: string) {
       try {
         // Delete from JIRA
         await client.deleteWorklog(worklogDetails.issueKey, worklogId);
-        
+
         // Remove from local storage if it exists there
         removeStoredWorklog(worklogId);
-        
+
         console.log('✅ Worklog successfully deleted!');
-        console.log(`🗑️  Removed ${secondsToJiraFormat(worklogDetails.worklog.timeSpentSeconds || 0)} from ${worklogDetails.issueKey}`);
-        
+        console.log(
+          `🗑️  Removed ${secondsToJiraFormat(worklogDetails.worklog.timeSpentSeconds || 0)} from ${worklogDetails.issueKey}`
+        );
       } catch (error) {
-        console.error('❌ Failed to delete worklog from JIRA:', error instanceof Error ? error.message : error);
+        console.error(
+          '❌ Failed to delete worklog from JIRA:',
+          error instanceof Error ? error.message : error
+        );
         console.log('💡 The worklog may have already been deleted or you may not have permission.');
         return;
       }
@@ -199,7 +216,6 @@ export async function undoWorklogById(worklogId: string) {
       console.log(`   Browse to the issue → Worklogs → Delete worklog ${worklogId}`);
       return;
     }
-
   } catch (error) {
     console.error('❌ Error:', error instanceof Error ? error.message : error);
   }

--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -1,0 +1,138 @@
+import { createClient } from '../api/jira-client.js';
+import { 
+  getRecentStoredWorklogs, 
+  getStoredWorklogById, 
+  removeStoredWorklog
+} from '../utils/worklog-storage.js';
+import { secondsToJiraFormat } from '../utils/time-parser.js';
+
+/**
+ * Show interactive selection of recent worklogs to undo
+ */
+export async function showUndoSelection() {
+  try {
+    const client = createClient();
+    
+    // Test connection
+    const isConnected = await client.testConnection();
+    if (!isConnected) {
+      console.log('❌ Failed to connect to JIRA');
+      return;
+    }
+
+    const recentWorklogs = getRecentStoredWorklogs(7); // Last 7 days
+    
+    if (recentWorklogs.length === 0) {
+      console.log('📭 No recent worklogs found to undo.');
+      console.log('💡 Only worklogs created via bookr CLI can be undone.');
+      return;
+    }
+
+    console.log('🔄 Recent worklogs that can be undone:');
+    console.log('─'.repeat(120));
+    console.log(`${'ID'.padEnd(15)} | ${'Issue'.padEnd(12)} | ${'Time'.padEnd(8)} | ${'Summary'.padEnd(50)} | Date`);
+    console.log('─'.repeat(120));
+
+    for (const worklog of recentWorklogs) {
+      const date = new Date(worklog.started).toLocaleDateString();
+      const time = new Date(worklog.started).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      const timeDisplay = secondsToJiraFormat(worklog.timeSpentSeconds);
+      const summary = worklog.issueSummary.length > 48 
+        ? worklog.issueSummary.substring(0, 45) + '...' 
+        : worklog.issueSummary;
+      
+      console.log(
+        `${worklog.id.padEnd(15)} | ${worklog.issueKey.padEnd(12)} | ${timeDisplay.padEnd(8)} | ${summary.padEnd(50)} | ${date} ${time}`
+      );
+    }
+
+    console.log('─'.repeat(120));
+    console.log('');
+    console.log('💡 To undo a specific worklog, run: bookr undo <WORKLOG_ID>');
+    console.log('⚠️  Warning: This will permanently delete the worklog from JIRA!');
+
+  } catch (error) {
+    console.error('❌ Error:', error instanceof Error ? error.message : error);
+  }
+}
+
+/**
+ * Undo a specific worklog by ID
+ */
+export async function undoWorklogById(worklogId: string) {
+  try {
+    const client = createClient();
+    
+    // Test connection
+    const isConnected = await client.testConnection();
+    if (!isConnected) {
+      console.log('❌ Failed to connect to JIRA');
+      return;
+    }
+
+    // Find the worklog in local storage
+    const storedWorklog = getStoredWorklogById(worklogId);
+    if (!storedWorklog) {
+      console.log(`❌ Worklog with ID ${worklogId} not found in local storage.`);
+      console.log('💡 Only worklogs created via bookr CLI can be undone.');
+      console.log('💡 Run "bookr undo" to see available worklogs.');
+      return;
+    }
+
+    // Show worklog details for confirmation
+    console.log('🔄 About to delete the following worklog:');
+    console.log('─'.repeat(80));
+    console.log(`Issue: ${storedWorklog.issueKey} - ${storedWorklog.issueSummary}`);
+    console.log(`Time: ${secondsToJiraFormat(storedWorklog.timeSpentSeconds)} (${storedWorklog.timeSpent})`);
+    if (storedWorklog.comment) {
+      console.log(`Comment: ${storedWorklog.comment}`);
+    }
+    const date = new Date(storedWorklog.started).toLocaleString();
+    console.log(`Date: ${date}`);
+    console.log('─'.repeat(80));
+
+    // In a CLI environment, we'll proceed directly
+    // In a real implementation, you might want to add a confirmation prompt
+    console.log('⏳ Deleting worklog from JIRA...');
+
+    try {
+      // Delete from JIRA
+      await client.deleteWorklog(storedWorklog.issueKey, storedWorklog.id);
+      
+      // Remove from local storage
+      removeStoredWorklog(storedWorklog.id);
+      
+      console.log('✅ Worklog successfully deleted!');
+      console.log(`🗑️  Removed ${secondsToJiraFormat(storedWorklog.timeSpentSeconds)} from ${storedWorklog.issueKey}`);
+      
+    } catch (error) {
+      console.error('❌ Failed to delete worklog from JIRA:', error instanceof Error ? error.message : error);
+      console.log('💡 The worklog may have already been deleted or you may not have permission.');
+      
+      // Ask if they want to remove from local storage anyway
+      console.log('');
+      console.log('❓ Remove from local storage anyway? This will prevent further undo attempts.');
+      console.log('💡 You can manually verify in JIRA and then run this command again.');
+      
+      // For now, we'll leave it in local storage so user can try again
+      return;
+    }
+
+  } catch (error) {
+    console.error('❌ Error:', error instanceof Error ? error.message : error);
+  }
+}
+
+/**
+ * Main undo function - handles both cases
+ */
+export async function handleUndo(worklogId?: string) {
+  if (worklogId) {
+    await undoWorklogById(worklogId);
+  } else {
+    await showUndoSelection();
+  }
+}
+
+// Default export for CLI usage
+export default handleUndo;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 import { useEffect, useState } from 'react';
 import { createClient } from '../api/jira-client.js';
 import type { JiraIssue } from '../types/jira.js';
-import { getTicketFromBranch, getCurrentBranch, isGitRepository } from '../utils/git.js';
+import { getCurrentBranch, getTicketFromBranch, isGitRepository } from '../utils/git.js';
 import {
   formatJiraDate,
   formatTimeForDisplay,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -11,6 +11,7 @@ import {
   parseTimeToSeconds,
   secondsToJiraFormat,
 } from '../utils/time-parser.js';
+import { storeWorklog } from '../utils/worklog-storage.js';
 import { ConfirmationPrompt } from './ConfirmationPrompt.js';
 
 interface AppProps {
@@ -123,12 +124,16 @@ export const App: React.FC<AppProps> = ({ input: _input, flags }) => {
     try {
       const client = createClient();
       const timeSpentSeconds = parseTimeToSeconds(timeSpent);
+      const comment = flags.description || 'Work logged via Bookr CLI';
 
-      await client.addWorklog(jiraIssue.key, {
+      const createdWorklog = await client.addWorklog(jiraIssue.key, {
         timeSpent: secondsToJiraFormat(timeSpentSeconds),
-        comment: flags.description || 'Work logged via Bookr CLI',
+        comment,
         started: formatJiraDate(new Date()),
       });
+
+      // Store the worklog locally for potential undo
+      storeWorklog(jiraIssue, createdWorklog, comment);
 
       setAppState('success');
     } catch (error) {

--- a/src/types/tempo.ts
+++ b/src/types/tempo.ts
@@ -1,0 +1,21 @@
+export interface TempoWorklog {
+  id?: string;
+  tempoWorklogId?: number;
+  timeSpentSeconds?: number;
+  timeSpent?: string;
+  description?: string;
+  started?: string;
+  issue?: {
+    id: string;
+    key?: string;
+  };
+}
+
+export interface TempoWorklogsResponse {
+  results: TempoWorklog[];
+  metadata?: {
+    count?: number;
+    offset?: number;
+    limit?: number;
+  };
+} 

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import envPaths from 'env-paths';
 

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,38 @@
+/**
+ * Execute a function on array items with limited concurrency
+ * This implementation avoids stack overflow, race conditions, and type safety issues
+ */
+export async function parallelMapLimit<T, R>(
+  arr: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  if (arr.length === 0) {
+    return [];
+  }
+
+  const results: R[] = new Array(arr.length);
+  let nextIndex = 0;
+
+  // Create a worker function that processes items sequentially
+  const worker = async (): Promise<void> => {
+    while (nextIndex < arr.length) {
+      const currentIndex = nextIndex++;
+      const item = arr[currentIndex];
+      
+      if (item !== undefined) {
+        results[currentIndex] = await fn(item);
+      }
+    }
+  };
+
+  // Start the specified number of workers
+  const workers = Array(Math.min(limit, arr.length))
+    .fill(null)
+    .map(() => worker());
+
+  // Wait for all workers to complete
+  await Promise.all(workers);
+
+  return results;
+} 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,10 +3,14 @@ import path from 'node:path';
 import envPaths from 'env-paths';
 import type { JiraAuth } from '../types/jira.js';
 
+export interface BookrConfig extends JiraAuth {
+  tempoApiToken?: string;
+}
+
 /**
- * Load JIRA configuration from config file
+ * Load JIRA and Tempo configuration from config file
  */
-export function loadConfigFromFile(): Partial<JiraAuth> | null {
+export function loadConfigFromFile(): Partial<BookrConfig> | null {
   try {
     const configFile = path.join(envPaths('bookr').config, 'config.json');
     if (fs.existsSync(configFile)) {
@@ -16,6 +20,7 @@ export function loadConfigFromFile(): Partial<JiraAuth> | null {
         baseUrl: parsed.JIRA_BASE_URL,
         email: parsed.JIRA_EMAIL,
         apiToken: parsed.JIRA_API_TOKEN,
+        tempoApiToken: parsed.TEMPO_API_TOKEN,
       };
     }
     return null;
@@ -28,6 +33,8 @@ export function saveConfigToFile(config: {
   JIRA_BASE_URL: string;
   JIRA_EMAIL: string;
   JIRA_API_TOKEN: string;
+  TEMPO_API_TOKEN?: string;
+  TEMPO_BASE_URL?: string;
 }): void {
   const configFile = path.join(envPaths('bookr').config, 'config.json');
   fs.writeFileSync(configFile, JSON.stringify(config, null, 2));

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -24,7 +24,11 @@ export function loadConfigFromFile(): Partial<JiraAuth> | null {
   }
 }
 
-export function saveConfigToFile(config: any): void {
+export function saveConfigToFile(config: {
+  JIRA_BASE_URL: string;
+  JIRA_EMAIL: string;
+  JIRA_API_TOKEN: string;
+}): void {
   const configFile = path.join(envPaths('bookr').config, 'config.json');
   fs.writeFileSync(configFile, JSON.stringify(config, null, 2));
 }

--- a/src/utils/worklog-storage.ts
+++ b/src/utils/worklog-storage.ts
@@ -161,19 +161,6 @@ export function getTodaysStoredWorklogs(): StoredWorklog[] {
   });
 }
 
-/**
- * Get recent stored worklogs (last 10 days)
- */
-export function getRecentStoredWorklogs(days = 10): StoredWorklog[] {
-  const data = readStoredWorklogs();
-  const cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - days);
-
-  return data.worklogs.filter((worklog) => {
-    const worklogDate = new Date(worklog.started);
-    return worklogDate >= cutoffDate;
-  });
-}
 
 /**
  * Clean up old worklogs (older than 30 days)

--- a/src/utils/worklog-storage.ts
+++ b/src/utils/worklog-storage.ts
@@ -1,0 +1,204 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import envPaths from 'env-paths';
+import type { JiraIssue, JiraWorklog } from '../types/jira.js';
+
+export interface StoredWorklog {
+  id: string; // Jira worklog ID
+  issueKey: string;
+  issueId: string;
+  issueSummary: string;
+  timeSpent: string;
+  timeSpentSeconds: number;
+  comment?: string;
+  started: string;
+  createdAt: string; // When it was created via bookr
+  author: {
+    name: string;
+    displayName: string;
+  };
+}
+
+interface WorklogStorageData {
+  worklogs: StoredWorklog[];
+  lastCleanup: string;
+}
+
+/**
+ * Get worklog storage file path
+ */
+export function getWorklogStoragePath(): string {
+  const paths = envPaths('bookr-cli', { suffix: '' });
+  return join(paths.data, 'worklogs.json');
+}
+
+/**
+ * Read stored worklogs
+ */
+export function readStoredWorklogs(): WorklogStorageData {
+  try {
+    const storagePath = getWorklogStoragePath();
+    if (!existsSync(storagePath)) {
+      return { worklogs: [], lastCleanup: new Date().toISOString() };
+    }
+
+    const content = readFileSync(storagePath, 'utf-8');
+    const data = JSON.parse(content) as WorklogStorageData;
+    
+    // Ensure we have the expected structure
+    if (!data.worklogs || !Array.isArray(data.worklogs)) {
+      return { worklogs: [], lastCleanup: new Date().toISOString() };
+    }
+    
+    return data;
+  } catch {
+    return { worklogs: [], lastCleanup: new Date().toISOString() };
+  }
+}
+
+/**
+ * Write stored worklogs
+ */
+export function writeStoredWorklogs(data: WorklogStorageData): void {
+  try {
+    const storagePath = getWorklogStoragePath();
+    const storageDir = dirname(storagePath);
+
+    // Ensure storage directory exists
+    if (!existsSync(storageDir)) {
+      mkdirSync(storageDir, { recursive: true });
+    }
+
+    writeFileSync(storagePath, JSON.stringify(data, null, 2));
+  } catch {
+    // Silently fail storage writes
+  }
+}
+
+/**
+ * Store a worklog after creation
+ */
+export function storeWorklog(
+  issue: JiraIssue,
+  worklog: JiraWorklog,
+  originalComment?: string
+): boolean {
+  try {
+    if (!worklog.id || !worklog.author) {
+      return false;
+    }
+
+    const data = readStoredWorklogs();
+    
+    const storedWorklog: StoredWorklog = {
+      id: worklog.id,
+      issueKey: issue.key,
+      issueId: issue.id,
+      issueSummary: issue.fields.summary,
+      timeSpent: worklog.timeSpent,
+      timeSpentSeconds: worklog.timeSpentSeconds || 0,
+      comment: originalComment || undefined,
+      started: worklog.started || new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      author: worklog.author,
+    };
+
+    // Add to the beginning of the array (most recent first)
+    data.worklogs.unshift(storedWorklog);
+    
+    // Keep only the last 100 worklogs to prevent unlimited growth
+    if (data.worklogs.length > 100) {
+      data.worklogs = data.worklogs.slice(0, 100);
+    }
+
+    writeStoredWorklogs(data);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get worklog by ID
+ */
+export function getStoredWorklogById(worklogId: string): StoredWorklog | null {
+  const data = readStoredWorklogs();
+  return data.worklogs.find(w => w.id === worklogId) || null;
+}
+
+/**
+ * Remove worklog from storage after deletion
+ */
+export function removeStoredWorklog(worklogId: string): boolean {
+  try {
+    const data = readStoredWorklogs();
+    const originalLength = data.worklogs.length;
+    data.worklogs = data.worklogs.filter(w => w.id !== worklogId);
+    
+    if (data.worklogs.length < originalLength) {
+      writeStoredWorklogs(data);
+      return true;
+    }
+    
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get today's stored worklogs
+ */
+export function getTodaysStoredWorklogs(): StoredWorklog[] {
+  const data = readStoredWorklogs();
+  const today = new Date();
+  const startOfDay = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const endOfDay = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59);
+
+  return data.worklogs.filter(worklog => {
+    const worklogDate = new Date(worklog.started);
+    return worklogDate >= startOfDay && worklogDate <= endOfDay;
+  });
+}
+
+/**
+ * Get recent stored worklogs (last 10 days)
+ */
+export function getRecentStoredWorklogs(days = 10): StoredWorklog[] {
+  const data = readStoredWorklogs();
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - days);
+
+  return data.worklogs.filter(worklog => {
+    const worklogDate = new Date(worklog.started);
+    return worklogDate >= cutoffDate;
+  });
+}
+
+/**
+ * Clean up old worklogs (older than 30 days)
+ */
+export function cleanupOldWorklogs(): number {
+  try {
+    const data = readStoredWorklogs();
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - 30);
+
+    const originalLength = data.worklogs.length;
+    data.worklogs = data.worklogs.filter(worklog => {
+      const worklogDate = new Date(worklog.createdAt);
+      return worklogDate >= cutoffDate;
+    });
+
+    const removedCount = originalLength - data.worklogs.length;
+    
+    if (removedCount > 0) {
+      data.lastCleanup = new Date().toISOString();
+      writeStoredWorklogs(data);
+    }
+
+    return removedCount;
+  } catch {
+    return 0;
+  }
+}

--- a/test/api/jira-client.test.ts
+++ b/test/api/jira-client.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { JiraClient } from '@/api/jira-client';
 import type { JiraAuth, JiraIssue, JiraUser, JiraWorklog } from '@/types/jira';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock fetch globally
 global.fetch = vi.fn() as any;

--- a/test/api/jira-client.test.ts
+++ b/test/api/jira-client.test.ts
@@ -54,6 +54,7 @@ describe('JiraClient', () => {
             Authorization: 'Basic dGVzdEBleGFtcGxlLmNvbTp0ZXN0LXRva2Vu',
             Accept: 'application/json',
             'Content-Type': 'application/json',
+            'User-Agent': 'bookr-cli/1.0',
           },
         }
       );
@@ -106,6 +107,7 @@ describe('JiraClient', () => {
           Authorization: 'Basic dGVzdEBleGFtcGxlLmNvbTp0ZXN0LXRva2Vu',
           Accept: 'application/json',
           'Content-Type': 'application/json',
+          'User-Agent': 'bookr-cli/1.0',
         },
       });
       expect(result).toEqual(mockUser);
@@ -143,6 +145,7 @@ describe('JiraClient', () => {
             Authorization: 'Basic dGVzdEBleGFtcGxlLmNvbTp0ZXN0LXRva2Vu',
             Accept: 'application/json',
             'Content-Type': 'application/json',
+            'User-Agent': 'bookr-cli/1.0',
           },
           body: expect.stringContaining('"timeSpentSeconds":3600'),
         }

--- a/test/integration/issue-extraction.test.ts
+++ b/test/integration/issue-extraction.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { getTicketFromBranch } from '../../src/utils/git.js';
 
 describe('Issue Extraction Integration', () => {
@@ -7,67 +7,67 @@ describe('Issue Extraction Integration', () => {
       {
         branch: 'feature/SUM25-176/course-information-import',
         expected: 'SUM25-176',
-        description: 'Feature branch with issue key'
+        description: 'Feature branch with issue key',
       },
       {
         branch: 'feature/TEMP-123-add-cli-tool',
         expected: 'TEMP-123',
-        description: 'Feature branch with issue key and description'
+        description: 'Feature branch with issue key and description',
       },
       {
         branch: 'bugfix/PROJ-456/fix-login',
         expected: 'PROJ-456',
-        description: 'Bugfix branch with issue key'
+        description: 'Bugfix branch with issue key',
       },
       {
         branch: 'feature/WILLEMII-62-test-integration',
         expected: 'WILLEMII-62',
-        description: 'Feature branch with issue key'
+        description: 'Feature branch with issue key',
       },
       {
         branch: 'TEMP-789-update-docs',
         expected: 'TEMP-789',
-        description: 'Direct issue key prefix'
+        description: 'Direct issue key prefix',
       },
       {
         branch: 'main',
         expected: null,
-        description: 'Main branch (no issue key)'
+        description: 'Main branch (no issue key)',
       },
       {
         branch: 'develop',
         expected: null,
-        description: 'Develop branch (no issue key)'
+        description: 'Develop branch (no issue key)',
       },
       {
         branch: 'hotfix/urgent-fix',
         expected: null,
-        description: 'Hotfix without issue key'
+        description: 'Hotfix without issue key',
       },
       {
         branch: 'feature/ABC-123-DEF-456/dual-issues',
         expected: 'ABC-123',
-        description: 'Multiple issue keys (should get first)'
+        description: 'Multiple issue keys (should get first)',
       },
       {
         branch: 'release/v1.2.3',
         expected: null,
-        description: 'Release branch (no issue key)'
-      }
+        description: 'Release branch (no issue key)',
+      },
     ];
 
     console.log('🧪 Testing JIRA issue key extraction:\n');
 
     for (const { branch, expected, description } of testCases) {
       const result = getTicketFromBranch(branch);
-      
+
       console.log(`Branch: ${branch}`);
       console.log(`Expected: ${expected || 'None'}`);
       console.log(`Result: ${result || 'None'}`);
       console.log(`Description: ${description}`);
       console.log(`Status: ${result === expected ? '✅ PASS' : '❌ FAIL'}`);
       console.log('---');
-      
+
       expect(result).toBe(expected);
     }
   });
@@ -77,47 +77,47 @@ describe('Issue Extraction Integration', () => {
       {
         branch: '',
         expected: null,
-        description: 'Empty string'
+        description: 'Empty string',
       },
       {
         branch: 'ABC-123',
         expected: 'ABC-123',
-        description: 'Just issue key'
+        description: 'Just issue key',
       },
       {
         branch: 'abc-123',
         expected: 'ABC-123',
-        description: 'Lowercase issue key'
+        description: 'Lowercase issue key',
       },
       {
         branch: 'feature/ABC-123/',
         expected: 'ABC-123',
-        description: 'Trailing slash'
+        description: 'Trailing slash',
       },
       {
         branch: '/feature/ABC-123',
         expected: 'ABC-123',
-        description: 'Leading slash'
+        description: 'Leading slash',
       },
       {
         branch: 'feature/ABC-123-extra-dashes',
         expected: 'ABC-123',
-        description: 'Extra dashes after issue key'
-      }
+        description: 'Extra dashes after issue key',
+      },
     ];
 
     console.log('🧪 Testing edge cases:\n');
 
     for (const { branch, expected, description } of edgeCases) {
       const result = getTicketFromBranch(branch);
-      
+
       console.log(`Branch: "${branch}"`);
       console.log(`Expected: ${expected || 'None'}`);
       console.log(`Result: ${result || 'None'}`);
       console.log(`Description: ${description}`);
       console.log(`Status: ${result === expected ? '✅ PASS' : '❌ FAIL'}`);
       console.log('---');
-      
+
       expect(result).toBe(expected);
     }
   });
@@ -136,14 +136,14 @@ describe('Issue Extraction Integration', () => {
 
     for (const { branch, expected } of projectKeyTests) {
       const result = getTicketFromBranch(branch);
-      
+
       console.log(`Branch: ${branch}`);
       console.log(`Expected: ${expected}`);
       console.log(`Result: ${result || 'None'}`);
       console.log(`Status: ${result === expected ? '✅ PASS' : '❌ FAIL'}`);
       console.log('---');
-      
+
       expect(result).toBe(expected);
     }
   });
-}); 
+});

--- a/test/integration/issues.test.ts
+++ b/test/integration/issues.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { createClient } from '../../src/api/jira-client.js';
 import type { JiraClient } from '../../src/api/jira-client.js';
 
@@ -12,7 +12,7 @@ describe('JIRA Integration - Issues', () => {
       console.log('   Set JIRA_BASE_URL, JIRA_EMAIL, and JIRA_API_TOKEN to run these tests');
       return;
     }
-    
+
     client = createClient();
   });
 
@@ -23,13 +23,13 @@ describe('JIRA Integration - Issues', () => {
     }
 
     const user = await client.getCurrentUser();
-    
+
     expect(user).toHaveProperty('displayName');
     expect(user).toHaveProperty('emailAddress');
     expect(user).toHaveProperty('accountId');
     expect(typeof user.displayName).toBe('string');
     expect(typeof user.emailAddress).toBe('string');
-    
+
     console.log(`👤 Logged in as: ${user.displayName} (${user.emailAddress})`);
   });
 
@@ -41,9 +41,9 @@ describe('JIRA Integration - Issues', () => {
 
     try {
       const issues = await client.getMyRecentIssues(5);
-      
+
       expect(Array.isArray(issues)).toBe(true);
-      
+
       if (issues.length > 0) {
         console.log('📋 Recent issues found:');
         issues.forEach((issue, index) => {
@@ -51,9 +51,11 @@ describe('JIRA Integration - Issues', () => {
           expect(issue).toHaveProperty('fields.summary');
           expect(issue).toHaveProperty('fields.status.name');
           expect(issue).toHaveProperty('fields.project.name');
-          
+
           console.log(`   ${index + 1}. ${issue.key} - ${issue.fields.summary}`);
-          console.log(`      Status: ${issue.fields.status.name} | Project: ${issue.fields.project.name}`);
+          console.log(
+            `      Status: ${issue.fields.status.name} | Project: ${issue.fields.project.name}`
+          );
         });
       } else {
         console.log('📋 No recent issues found assigned to you.');
@@ -66,7 +68,7 @@ describe('JIRA Integration - Issues', () => {
       console.log('   - No assigned issues');
       console.log('   - Insufficient permissions');
       console.log('   - JIRA API limitations');
-      
+
       // Still expect an error to be thrown
       expect(error).toBeInstanceOf(Error);
     }
@@ -82,14 +84,14 @@ describe('JIRA Integration - Issues', () => {
       // Search for issues updated in the last 30 days
       const jql = 'updated >= -30d ORDER BY updated DESC';
       const result = await client.searchIssues(jql, 3);
-      
+
       expect(result).toHaveProperty('issues');
       expect(result).toHaveProperty('total');
       expect(Array.isArray(result.issues)).toBe(true);
       expect(typeof result.total).toBe('number');
-      
+
       console.log(`🔍 Found ${result.total} issues (showing ${result.issues.length})`);
-      
+
       if (result.issues.length > 0) {
         result.issues.forEach((issue, index) => {
           expect(issue).toHaveProperty('key');
@@ -100,7 +102,7 @@ describe('JIRA Integration - Issues', () => {
     } catch (error) {
       console.log('⚠️  Could not search for issues:');
       console.log(`   ${error instanceof Error ? error.message : 'Unknown error'}`);
-      
+
       // Still expect an error to be thrown
       expect(error).toBeInstanceOf(Error);
     }
@@ -122,25 +124,27 @@ describe('JIRA Integration - Issues', () => {
 
     try {
       const worklogsResponse = await client.getWorklogs(testIssueKey);
-      
+
       expect(worklogsResponse).toHaveProperty('worklogs');
       expect(Array.isArray(worklogsResponse.worklogs)).toBe(true);
-      
+
       console.log(`📝 Found ${worklogsResponse.worklogs.length} worklogs for ${testIssueKey}`);
-      
+
       if (worklogsResponse.worklogs.length > 0) {
         worklogsResponse.worklogs.slice(0, 3).forEach((worklog, index) => {
           expect(worklog).toHaveProperty('id');
           expect(worklog).toHaveProperty('timeSpentSeconds');
-          console.log(`   ${index + 1}. ${worklog.timeSpentSeconds}s - ${worklog.comment || 'No comment'}`);
+          console.log(
+            `   ${index + 1}. ${worklog.timeSpentSeconds}s - ${worklog.comment || 'No comment'}`
+          );
         });
       }
     } catch (error) {
       console.log('⚠️  Could not fetch worklogs:');
       console.log(`   ${error instanceof Error ? error.message : 'Unknown error'}`);
-      
+
       // Still expect an error to be thrown
       expect(error).toBeInstanceOf(Error);
     }
   });
-}); 
+});

--- a/test/integration/jira-connection.test.ts
+++ b/test/integration/jira-connection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { createClient } from '../../src/api/jira-client.js';
 import type { JiraClient } from '../../src/api/jira-client.js';
 
@@ -12,7 +12,7 @@ describe('JIRA Integration - Connection', () => {
       console.log('   Set JIRA_BASE_URL, JIRA_EMAIL, and JIRA_API_TOKEN to run these tests');
       return;
     }
-    
+
     client = createClient();
   });
 
@@ -33,13 +33,13 @@ describe('JIRA Integration - Connection', () => {
     }
 
     const user = await client.getCurrentUser();
-    
+
     expect(user).toHaveProperty('displayName');
     expect(user).toHaveProperty('emailAddress');
     expect(user).toHaveProperty('accountId');
     expect(typeof user.displayName).toBe('string');
     expect(typeof user.emailAddress).toBe('string');
-    
+
     console.log(`👤 Logged in as: ${user.displayName} (${user.emailAddress})`);
   });
 
@@ -59,7 +59,7 @@ describe('JIRA Integration - Connection', () => {
     } catch (error) {
       // Expected to fail if PROJ-123 doesn't exist
       expect(error).toBeInstanceOf(Error);
-      console.log('⚠️  Issue retrieval failed (expected if PROJ-123 doesn\'t exist):');
+      console.log("⚠️  Issue retrieval failed (expected if PROJ-123 doesn't exist):");
       console.log(`   ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   });
@@ -72,4 +72,4 @@ describe('JIRA Integration - Connection', () => {
 
     await expect(client.getIssue('NONEXISTENT-999')).rejects.toThrow();
   });
-}); 
+});

--- a/test/integration/update-checker.test.ts
+++ b/test/integration/update-checker.test.ts
@@ -1,20 +1,20 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { checkForUpdates, forceCheckForUpdates } from '../../src/utils/update.js';
 
 describe('Update Checker Integration', () => {
   it('should check for updates normally (using cache)', async () => {
     const updateInfo = await checkForUpdates();
-    
+
     expect(updateInfo).toHaveProperty('current');
     expect(updateInfo).toHaveProperty('latest');
     expect(updateInfo).toHaveProperty('hasUpdate');
     expect(updateInfo).toHaveProperty('isOutdated');
-    
+
     expect(typeof updateInfo.current).toBe('string');
     expect(typeof updateInfo.latest).toBe('string');
     expect(typeof updateInfo.hasUpdate).toBe('boolean');
     expect(typeof updateInfo.isOutdated).toBe('boolean');
-    
+
     console.log('📦 Update check results:');
     console.log(`   Current version: ${updateInfo.current}`);
     console.log(`   Latest version: ${updateInfo.latest}`);
@@ -24,17 +24,17 @@ describe('Update Checker Integration', () => {
 
   it('should force check for updates (ignoring cache)', async () => {
     const forceUpdateInfo = await forceCheckForUpdates();
-    
+
     expect(forceUpdateInfo).toHaveProperty('current');
     expect(forceUpdateInfo).toHaveProperty('latest');
     expect(forceUpdateInfo).toHaveProperty('hasUpdate');
     expect(forceUpdateInfo).toHaveProperty('isOutdated');
-    
+
     expect(typeof forceUpdateInfo.current).toBe('string');
     expect(typeof forceUpdateInfo.latest).toBe('string');
     expect(typeof forceUpdateInfo.hasUpdate).toBe('boolean');
     expect(typeof forceUpdateInfo.isOutdated).toBe('boolean');
-    
+
     console.log('📦 Force update check results:');
     console.log(`   Current version: ${forceUpdateInfo.current}`);
     console.log(`   Latest version: ${forceUpdateInfo.latest}`);
@@ -45,13 +45,13 @@ describe('Update Checker Integration', () => {
   it('should provide consistent version information', async () => {
     const normalCheck = await checkForUpdates();
     const forceCheck = await forceCheckForUpdates();
-    
+
     // Both checks should return the same current version
     expect(normalCheck.current).toBe(forceCheck.current);
-    
+
     // Both should have the same structure
     expect(Object.keys(normalCheck)).toEqual(Object.keys(forceCheck));
-    
+
     // Version strings should be valid semver format
     const semverRegex = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/;
     expect(normalCheck.current).toMatch(semverRegex);
@@ -61,7 +61,7 @@ describe('Update Checker Integration', () => {
 
   it('should handle update status correctly', async () => {
     const updateInfo = await checkForUpdates();
-    
+
     if (updateInfo.hasUpdate) {
       console.log('📦 Update available!');
       console.log('   Run: npm update -g bookr-cli');
@@ -72,16 +72,18 @@ describe('Update Checker Integration', () => {
       // This handles cases where current version is newer than what's published on npm
       const currentParts = updateInfo.current.split('.').map(Number);
       const latestParts = updateInfo.latest.split('.').map(Number);
-      
+
       // Compare versions: current should be >= latest when no update is available
-      const isCurrentNewerOrEqual = 
+      const isCurrentNewerOrEqual =
         currentParts[0] > latestParts[0] ||
         (currentParts[0] === latestParts[0] && currentParts[1] > latestParts[1]) ||
-        (currentParts[0] === latestParts[0] && currentParts[1] === latestParts[1] && currentParts[2] >= latestParts[2]);
-      
+        (currentParts[0] === latestParts[0] &&
+          currentParts[1] === latestParts[1] &&
+          currentParts[2] >= latestParts[2]);
+
       expect(isCurrentNewerOrEqual).toBe(true);
     }
-    
+
     // hasUpdate and isOutdated should be consistent
     if (updateInfo.hasUpdate) {
       expect(updateInfo.isOutdated).toBe(true);
@@ -89,4 +91,4 @@ describe('Update Checker Integration', () => {
       expect(updateInfo.isOutdated).toBe(false);
     }
   });
-}); 
+});

--- a/test/integration/worklog.test.ts
+++ b/test/integration/worklog.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { createClient } from '../../src/api/jira-client.js';
 import type { JiraClient } from '../../src/api/jira-client.js';
-import { formatJiraDate, parseTimeToSeconds, secondsToJiraFormat } from '../../src/utils/time-parser.js';
+import {
+  formatJiraDate,
+  parseTimeToSeconds,
+  secondsToJiraFormat,
+} from '../../src/utils/time-parser.js';
 
 describe('JIRA Integration - Worklog', () => {
   let client: JiraClient | null = null;
@@ -13,7 +17,7 @@ describe('JIRA Integration - Worklog', () => {
       console.log('   Set JIRA_BASE_URL, JIRA_EMAIL, and JIRA_API_TOKEN to run these tests');
       return;
     }
-    
+
     client = createClient();
   });
 
@@ -47,12 +51,12 @@ describe('JIRA Integration - Worklog', () => {
 
     try {
       const result = await client.addWorklog(issueKey, worklog);
-      
+
       expect(result).toHaveProperty('id');
       expect(result).toHaveProperty('timeSpentSeconds');
       expect(typeof result.id).toBe('string');
       expect(typeof result.timeSpentSeconds).toBe('number');
-      
+
       console.log('✅ Worklog created successfully!');
       console.log(`   Worklog ID: ${result.id}`);
       console.log(`   Time spent: ${result.timeSpentSeconds} seconds`);
@@ -64,7 +68,7 @@ describe('JIRA Integration - Worklog', () => {
       console.log('   - Issue key not existing');
       console.log('   - Insufficient permissions');
       console.log('   - Invalid issue key format');
-      
+
       // Still expect an error to be thrown
       expect(error).toBeInstanceOf(Error);
     }
@@ -76,7 +80,7 @@ describe('JIRA Integration - Worklog', () => {
     expect(parseTimeToSeconds('1h')).toBe(3600);
     expect(parseTimeToSeconds('1h30m')).toBe(5400);
     expect(parseTimeToSeconds('2.5h')).toBe(9000);
-    
+
     expect(secondsToJiraFormat(1800)).toBe('30m');
     expect(secondsToJiraFormat(3600)).toBe('1h');
     expect(secondsToJiraFormat(5400)).toBe('1h 30m');
@@ -86,8 +90,8 @@ describe('JIRA Integration - Worklog', () => {
   it('should format dates correctly for JIRA', () => {
     const testDate = new Date('2024-01-15T10:30:00.000Z');
     const formatted = formatJiraDate(testDate);
-    
+
     // Should be in ISO format with timezone offset
     expect(formatted).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{4}$/);
   });
-}); 
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,4 +1,4 @@
-import { beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 
 // Global test setup
 beforeAll(() => {

--- a/test/utils/cache.test.ts
+++ b/test/utils/cache.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { readCache, writeCache, clearCache } from '@/utils/cache.js';
+import { clearCache, readCache, writeCache } from '@/utils/cache.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('env-paths', () => ({
   default: () => ({ cache: '/mock' }),
@@ -11,10 +11,10 @@ vi.mock('node:path');
 
 describe('Cache Utils', () => {
   const mockCachePath = '/mock/update-cache.json';
-  const mockCache = { 
+  const mockCache = {
     lastCheck: Date.now(),
     latestVersion: '1.0.0',
-    updateAvailable: false
+    updateAvailable: false,
   };
 
   beforeEach(() => {

--- a/test/utils/config.test.ts
+++ b/test/utils/config.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { loadConfigFromFile, saveConfigToFile } from '@/utils/config.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('env-paths', () => ({
   default: () => ({ config: '/mock' }),

--- a/test/utils/date.test.ts
+++ b/test/utils/date.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
 import { getTodayISO, getYesterdayISO } from '@/utils/date.js';
+import { describe, expect, it } from 'vitest';
 
 describe('Date Utils', () => {
   it("should return today's date in ISO format", () => {

--- a/test/utils/git-simple.test.ts
+++ b/test/utils/git-simple.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
 import { getTicketFromBranch } from '@/utils/git.js';
+import { describe, expect, it } from 'vitest';
 
 describe('Git Utils - Pure Functions', () => {
   describe('getTicketFromBranch', () => {

--- a/test/utils/time-parser.test.ts
+++ b/test/utils/time-parser.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect } from 'vitest';
 import {
+  formatJiraDate,
+  formatTimeForDisplay,
+  isValidTimeFormat,
   parseTimeToSeconds,
   secondsToJiraFormat,
-  isValidTimeFormat,
-  formatTimeForDisplay,
-  formatJiraDate,
 } from '@/utils/time-parser.js';
+import { describe, expect, it } from 'vitest';
 
 describe('parseTimeToSeconds', () => {
   it('should parse decimal hours correctly', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vitest/config';
 import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
@@ -8,7 +8,7 @@ export default defineConfig({
     setupFiles: ['./test/setup.ts'],
     include: [
       'test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-      'test/integration/**/*.test.ts'
+      'test/integration/**/*.test.ts',
     ],
     exclude: ['node_modules', 'dist', '.idea', '.git', '.cache'],
     coverage: {


### PR DESCRIPTION
Implement `bookr undo` command and enhance `bookr today` to allow users to easily revert any Jira worklog and view worklog IDs.

The `undo` command now works with any Jira worklog ID, providing a universal safety net for worklog management.